### PR TITLE
Rewrite of the _shift_key_indices function to make if faster

### DIFF
--- a/draftsman/classes/entitylist.py
+++ b/draftsman/classes/entitylist.py
@@ -488,17 +488,22 @@ class EntityList(MutableSequence):
         when inserting or removing elements before the end, which moves what
         index each key should point to.
         """
+
         # Shift the indices for key_to_idx
-        for key in self.key_map:
-            old_idx = self.key_to_idx[key]
-            if old_idx >= idx:
-                new_idx = old_idx + amt
-                self.key_to_idx[key] = new_idx
-                # del self.idx_to_key[old_idx]
-                # # self.idx_to_key.pop(old_idx)
-                # self.idx_to_key[new_idx] = key
+        self.key_to_idx = {key: old_idx + amt if old_idx >= idx else old_idx for key, old_idx in self.key_to_idx.items()}
+
+        # # Shift the indices for key_to_idx
+        # for key, old_idx in self.key_to_idx.items():
+        #     # old_idx = self.key_to_idx[key]
+        #     if old_idx >= idx:
+        #         new_idx = old_idx + amt
+        #         self.key_to_idx[key] = new_idx
+        #         # del self.idx_to_key[old_idx]
+        #         # # self.idx_to_key.pop(old_idx)
+        #         # self.idx_to_key[new_idx] = key
 
         # Reconstruct idx_to_key
-        self.idx_to_key = {}
-        for key in self.key_to_idx:
-            self.idx_to_key[self.key_to_idx[key]] = key
+        # self.idx_to_key = {}
+        # for key in self.key_to_idx:
+        #     self.idx_to_key[self.key_to_idx[key]] = key
+        self.idx_to_key = {value: key for key, value in self.key_to_idx.items()}


### PR DESCRIPTION
I rewrote the _shift_key_indices function using dictionary comprehension, to make it run a lot faster (from 21 seconds down to 4.7 on a big blueprint). This function was responsible for more than 75% of the time spent. (Total time got from 47 seconds down to 14)
This was especially true for big blueprints with many entities.
I ran the test suite and coverage, and all 396 tests passed.
(I left the old code commented to make it easier to understand, as it's more verbose)

Before:
![image](https://user-images.githubusercontent.com/23664359/173725153-d0a91d33-c9cc-4134-8f04-849579207055.png)

After:
![image](https://user-images.githubusercontent.com/23664359/173725330-912950b6-e960-463e-8221-89167ab75e5f.png)
