### PR TITLE
loading blueprint from dict did not convert connection ids from numbers to associations

### DIFF
--- a/draftsman/classes/blueprint.py
+++ b/draftsman/classes/blueprint.py
@@ -96,34 +96,6 @@ class Blueprint(Transformable, TileCollection, EntityCollection):
 
         self.setup(**root["blueprint"])
 
-        # Convert circuit and power connections to Associations
-        for entity in self.entities:
-            if hasattr(entity, "connections"):  # Wire connections
-                connections = entity.connections
-                for side in connections:
-                    if side in {"1", "2"}:
-                        for color in connections[side]:
-                            connection_points = connections[side][color]
-                            for point in connection_points:
-                                old = point["entity_id"] - 1
-                                point["entity_id"] = Association(self.entities[old])
-
-                    elif side in {"Cu0", "Cu1"}:  # pragma: no branch
-                        connection_points = connections[side]
-                        for point in connection_points:
-                            old = point["entity_id"] - 1
-                            point["entity_id"] = Association(self.entities[old])
-
-            if hasattr(entity, "neighbours"):  # Power pole connections
-                neighbours = entity.neighbours
-                for i, neighbour in enumerate(neighbours):
-                    neighbours[i] = Association(self.entities[neighbour - 1])
-
-        # Change all locomotive numbers to use Associations
-        for schedule in self.schedules:
-            for i, locomotive in enumerate(schedule["locomotives"]):
-                schedule["locomotives"][i] = Association(self.entities[locomotive - 1])
-
     @utils.reissue_warnings
     def setup(self, **kwargs):
         """
@@ -225,6 +197,34 @@ class Blueprint(Transformable, TileCollection, EntityCollection):
                 DraftsmanWarning,
                 stacklevel=2,
             )
+
+        # Convert circuit and power connections to Associations
+        for entity in self.entities:
+            if hasattr(entity, "connections"):  # Wire connections
+                connections = entity.connections
+                for side in connections:
+                    if side in {"1", "2"}:
+                        for color in connections[side]:
+                            connection_points = connections[side][color]
+                            for point in connection_points:
+                                old = point["entity_id"] - 1
+                                point["entity_id"] = Association(self.entities[old])
+
+                    elif side in {"Cu0", "Cu1"}:  # pragma: no branch
+                        connection_points = connections[side]
+                        for point in connection_points:
+                            old = point["entity_id"] - 1
+                            point["entity_id"] = Association(self.entities[old])
+
+            if hasattr(entity, "neighbours"):  # Power pole connections
+                neighbours = entity.neighbours
+                for i, neighbour in enumerate(neighbours):
+                    neighbours[i] = Association(self.entities[neighbour - 1])
+
+        # Change all locomotive numbers to use Associations
+        for schedule in self.schedules:
+            for i, locomotive in enumerate(schedule["locomotives"]):
+                schedule["locomotives"][i] = Association(self.entities[locomotive - 1])
 
     # =========================================================================
     # Blueprint properties

--- a/draftsman/classes/mixins/io_type.py
+++ b/draftsman/classes/mixins/io_type.py
@@ -20,9 +20,9 @@ class IOTypeMixin(object):
         super(IOTypeMixin, self).__init__(name, similar_entities, **kwargs)
 
         self.io_type = "input"  # Default
-        if "io_type" in kwargs:
-            self.io_type = kwargs["io_type"]
-            self.unused_args.pop("io_type")
+        if "type" in kwargs:
+            self.io_type = kwargs["type"]
+            self.unused_args.pop("type")
         self._add_export(
             "io_type",
             lambda x: x is not None and x != "input",


### PR DESCRIPTION
moved this conversion from out of `load_from_string` to `setup`.  This will let loading from `dict` also convert connections/schedules to `Associations`.  Test passed, ran black.  

Additionally, `IOTypeMixin` was not looking for "type", not "io_type", inside of the `Entity` `dict` for underground belts.  This caused them to always be inputs and never outputs.  This fix broke test, and I don't really understand why.  The fix is correct though.  