### PR TITLE
fix type of BlueprintBook.insert

### DIFF
--- a/draftsman/classes/blueprintbook.py
+++ b/draftsman/classes/blueprintbook.py
@@ -105,7 +105,7 @@ class BlueprintableList(MutableSequence):
                     self.append(elem)
 
     def insert(self, idx, value):
-        # type: (int, Union[Blueprint, BlueprintBook]) -> None
+        # type: (int, Blueprintable) -> None
         # Make sure the blueprintable is valid
         self.check_blueprintable(value)
 


### PR DESCRIPTION
allow BlueprintBook to accept Blueprintable instead of Union[Blueprint,BlueprintBook]

only changing the type annotation