### PR TITLE
Add option to extend entity list along with a note about performance

### DIFF
--- a/draftsman/classes/blueprint.py
+++ b/draftsman/classes/blueprint.py
@@ -447,6 +447,8 @@ class Blueprint(Transformable, TileCollection, EntityCollection, Blueprintable):
         of a regular list, as well as some extra features. For more information
         on ``EntityList``, check out this writeup
         :ref:`here <handbook.blueprints.blueprint_differences>`.
+        Note - assigning to this triggers a deep copy, so use .append()
+        or .extend() if you're building incrementally.
         """
         return self._root["entities"]
 

--- a/draftsman/classes/entitylist.py
+++ b/draftsman/classes/entitylist.py
@@ -14,7 +14,7 @@ except ImportError:  # pragma: no coverage
     from collections import MutableSequence
 from copy import deepcopy
 import six
-from typing import Union, Any, TYPE_CHECKING
+from typing import Union, Any, List, TYPE_CHECKING
 import warnings
 
 if TYPE_CHECKING:  # pragma: no coverage
@@ -125,6 +125,33 @@ class EntityList(MutableSequence):
             assert blueprint.entities[-1].stack_size_override == 1
         """
         self.insert(len(self.data), name, copy=copy, merge=merge, **kwargs)
+
+    @utils.reissue_warnings
+    def extend(self, entities, copy=True, merge=False):
+        # type: (List[Union[str, EntityLike]], bool, bool, **dict) -> None
+        """
+        Extends the entity list with the list provided.
+        Functionally the same as appending one element at a time
+
+        :param copy: Passed through to append for each element
+        :param merge: Passed through to append for each element
+
+        :example:
+
+        .. code-block :: python
+
+            blueprint = Blueprint()
+            assert isinstance(blueprint.entities, EntityList)
+
+            # Append Entity instance
+            blueprint.entities.extend([Container("steel-chest"), Container("wooden-chest", tile_position=(1, 1)])
+            assert blueprint.entities[-2].name == "steel-chest"
+            assert blueprint.entities[-1].name == "wooden-chest"
+            assert blueprint.entities[-1].tile_position == {"x": 1, "y": 1}
+        """
+        for entity in entities:
+            self.append(entity, copy=copy, merge=merge)
+
 
     @utils.reissue_warnings
     def insert(self, idx, name, copy=True, merge=False, **kwargs):

--- a/test/test_entitylist.py
+++ b/test/test_entitylist.py
@@ -69,6 +69,18 @@ class EntityListTesting(unittest.TestCase):
         with self.assertRaises(ValueError):
             blueprint.entities.append(Container(), copy=False, merge=True)
 
+    def test_extend(self):
+        # Test appending a list vs individually
+        blueprint1 = Blueprint()
+        blueprint2 = Blueprint()
+        entity_list = [new_entity("transport-belt", tile_position=(0, 0)),
+                       new_entity("wooden-chest", tile_position=(1, 1))]
+        blueprint1.entities.extend(entity_list)
+        for e in entity_list:
+            blueprint2.entities.append(e)
+
+        self.assertEqual(blueprint1.to_dict(), blueprint2.to_dict())
+
     def test_remove(self):
         pass  # TODO
 


### PR DESCRIPTION
Add an extend option to EntityList.

I'm not certain of what `@utils.reissue_warnings` is doing, but other functions have it so I included it. Hope this is the correct option.