### PR TITLE
Problem with typing package on newer versions of python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         "lupa >= 2.0; python_version >= '3.0'",     # Modern Lupa
         "lupa == 1.14.1; python_version < '3.0'",   # Old Lupa, may break mod loading due to different Lua version
         "six >= 1.16.0",
-        "typing",
+        "typing; python_version < '3.8'",
         "typing_extensions; python_version < '3.8'",
         "importlib-resources; python_version < '3.7'",
         "enum34; python_version < '3.4'",

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         "lupa >= 2.0; python_version >= '3.0'",     # Modern Lupa
         "lupa == 1.14.1; python_version < '3.0'",   # Old Lupa, may break mod loading due to different Lua version
         "six >= 1.16.0",
-        "typing; python_version < '3.8'",
+        "typing; python_version < '3.5'",
         "typing_extensions; python_version < '3.8'",
         "importlib-resources; python_version < '3.7'",
         "enum34; python_version < '3.4'",


### PR DESCRIPTION
Hello, thank you for this package! I'm getting some strange errors after installing it and from what I can tell it seems to be related to the package `typing` on newer versions of python. I looked in your procjects requirements.txt and there seems to be a guard so I was a little bit confused as I have python 3.10. But digging a bit further this guard seems suspiciously absent in setup.py. I verified it works with this patch on my system, but I really don't have good enought of a mental model of pythons package system to say anything about whether this is the right thing, hopefully its on the right track.

Here is the original error:
```
Traceback (most recent call last):
  File "/Users/alan/Code/fdc/src/main.py", line 1, in <module>
    from draftsman.data import signals
  File "/Users/alan/Code/fdc/.venv/lib/python3.10/site-packages/draftsman/data/signals.py", line 13, in <module>
    import importlib.resources as pkg_resources  # type: ignore
  File "/nix/store/6xmv46hawz0iqgvzwllmagzqc9pws00d-python3-3.10.12/lib/python3.10/importlib/resources.py", line 4, in <module>
    from . import _common
  File "/nix/store/6xmv46hawz0iqgvzwllmagzqc9pws00d-python3-3.10.12/lib/python3.10/importlib/_common.py", line 9, in <module>
    from typing import Union, Any, Optional
  File "/Users/alan/Code/fdc/.venv/lib/python3.10/site-packages/typing.py", line 1359, in <module>
    class Callable(extra=collections_abc.Callable, metaclass=CallableMeta):
  File "/Users/alan/Code/fdc/.venv/lib/python3.10/site-packages/typing.py", line 1007, in __new__
    self._abc_registry = extra._abc_registry
AttributeError: type object 'Callable' has no attribute '_abc_registry'
```

And the logs from a clean install of your package v1.1.1
```
created virtual environment CPython3.10.12.final.0-64 in 358ms
  creator CPython3Posix(dest=/Users/alan/Code/fdc/.venv, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/Users/alan/Library/Application Support/virtualenv)
    added seed packages: pip==24.0, setuptools==69.2.0, wheel==0.43.0
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
Collecting factorio-draftsman==1.1.1 (from -r requirements.txt (line 1))
  Using cached factorio_draftsman-1.1.1-py3-none-any.whl.metadata (9.7 kB)
Collecting schema>=0.7.5 (from factorio-draftsman==1.1.1->-r requirements.txt (line 1))
  Using cached schema-0.7.7-py2.py3-none-any.whl.metadata (34 kB)
Collecting six>=1.16.0 (from factorio-draftsman==1.1.1->-r requirements.txt (line 1))
  Using cached six-1.16.0-py2.py3-none-any.whl.metadata (1.8 kB)
Collecting typing (from factorio-draftsman==1.1.1->-r requirements.txt (line 1))
  Using cached typing-3.7.4.3-py3-none-any.whl
Collecting lupa>=2.0 (from factorio-draftsman==1.1.1->-r requirements.txt (line 1))
  Using cached lupa-2.1-cp310-cp310-macosx_11_0_arm64.whl.metadata (57 kB)
Using cached factorio_draftsman-1.1.1-py3-none-any.whl (1.9 MB)
Using cached lupa-2.1-cp310-cp310-macosx_11_0_arm64.whl (975 kB)
Using cached schema-0.7.7-py2.py3-none-any.whl (18 kB)
Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: schema, lupa, typing, six, factorio-draftsman
Successfully installed factorio-draftsman-1.1.1 lupa-2.1 schema-0.7.7 six-1.16.0 typing-3.7.4.3
```