### PR TITLE
`draftsman` now prints usage/help on empty args.

### DIFF
--- a/draftsman/environment/script.py
+++ b/draftsman/environment/script.py
@@ -182,9 +182,10 @@ def main():
 
     args: DraftsmanCommandArgs = parser.parse_args(namespace=DraftsmanCommandArgs())
 
-    if args.operation == "version":
+    if not args.operation:
+        parser.print_help()
+    elif args.operation == "version":
         print("Draftsman {}".format(__version__))
-
     elif args.operation == "factorio-version":
         if args.desired_version is None:
             # Grab and populate the repo, making sure its a git repo we expect


### PR DESCRIPTION
Previously this was raising an exception and exiting with nonzero status.

No test, because I couldn't figure out where it goes in our infrastructure. Something under `test/tools` maybe?