### PR TITLE
Fix reversed operators in DeciderCombinator __ge__ and __le__ methods

### DIFF
--- a/draftsman/prototypes/decider_combinator.py
+++ b/draftsman/prototypes/decider_combinator.py
@@ -212,10 +212,10 @@ class DeciderInput:
         return self._output_condition("<", other)
 
     def __ge__(self, other) -> DeciderCondition:
-        return self._output_condition("<=", other)
+        return self._output_condition(">=", other)
 
     def __le__(self, other) -> DeciderCondition:
-        return self._output_condition(">=", other)
+        return self._output_condition("<=", other)
 
 
 class DeciderOutput(Temp):  # TODO: Exportable


### PR DESCRIPTION
This commit fixes a bug where the greater-than-or-equal (>=) and less-than-or-equal (<=) operators were reversed in the DeciderCombinator class implementation. The issue was causing incorrect behavior in circuit designs relying on these comparison operators.