### PR TITLE
Fix: Extract space-platform-starter-pack from Factorio data

### DIFF
--- a/draftsman/environment/update.py
+++ b/draftsman/environment/update.py
@@ -873,6 +873,7 @@ def get_items(lua):
     add_items(data.raw["repair-tool"])  # not an item somehow
     add_items(data.raw["rail-planner"])
     add_items(data.raw["copy-paste-tool"])
+    add_items(data.raw["space-platform-starter-pack"])
 
     # Sort everything
     for i, _ in enumerate(group_list):

--- a/test/data/test_items.py
+++ b/test/data/test_items.py
@@ -86,6 +86,7 @@ class TestItemsData:
         else:
             assert items.get_stack_size("rocket-fuel") == 20
             assert items.get_stack_size("space-science-pack") == 200
+            assert items.get_stack_size("space-platform-starter-pack") == 1
 
         # TODO: should this raise an error instead?
         assert items.get_stack_size("unknown!") == None


### PR DESCRIPTION
space-platform-starter-pack is a Space Age-specific prototype type (not in the standard 'item' type), so it must be explicitly extracted like other special items (blueprints, deconstruction-item, etc.). Without this, the item exists in factorio-data but isn't copied to draftsman-data.