### PR TITLE
Fix: Read surface properties from nested surface_properties dict

### DIFF
--- a/draftsman/data/planets.py
+++ b/draftsman/data/planets.py
@@ -28,9 +28,10 @@ def get_surface_properties(surface_name: str) -> dict:
         return {}
     else:
         surface = raw[surface_name]
+        surface_props = surface.get("surface_properties", {})
         return {
-            "solar-power": surface.get("solar-power", 100),
-            "magnetic-field": surface.get("magnetic-field", 90),
-            "pressure": surface.get("pressure", 1000),
-            "gravity": surface.get("gravity", 10),
+            "solar-power": surface_props.get("solar-power", 100),
+            "magnetic-field": surface_props.get("magnetic-field", 90),
+            "pressure": surface_props.get("pressure", 1000),
+            "gravity": surface_props.get("gravity", 10),
         }

--- a/test/data/test_planets.py
+++ b/test/data/test_planets.py
@@ -17,3 +17,9 @@ class TestPlanets:
             "pressure": 1000,
             "gravity": 10,
         }
+        assert planets.get_surface_properties("fulgora") == {
+            "solar-power": 20,
+            "magnetic-field": 99,
+            "pressure": 800,
+            "gravity": 8,
+        }


### PR DESCRIPTION
The get_surface_properties function was incorrectly reading properties (solar-power, magnetic-field, pressure, gravity) directly from the surface object. Now correctly reads from surface.get('surface_properties', {}) to match the actual data structure.

Added a test in data/planets.py to verify that Fulgora's data is now different that Nauvis'.